### PR TITLE
Fixed flaky test: testFlat1NoFlattenSpec - Checked each specification…

### DIFF
--- a/extensions-core/parquet-extensions/src/test/java/org/apache/druid/data/input/parquet/FlattenSpecParquetReaderTest.java
+++ b/extensions-core/parquet-extensions/src/test/java/org/apache/druid/data/input/parquet/FlattenSpecParquetReaderTest.java
@@ -19,6 +19,8 @@
 
 package org.apache.druid.data.input.parquet;
 
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
 import com.google.common.collect.ImmutableList;
 import org.apache.druid.data.input.ColumnsFilter;
 import org.apache.druid.data.input.InputEntityReader;
@@ -49,14 +51,6 @@ public class FlattenSpecParquetReaderTest extends BaseParquetReaderTest
                                           + "  \"metric1\" : 1,\n"
                                           + "  \"timestamp\" : 1537229880023\n"
                                           + "}";
-
-  private static final String LISTDIM = "\"listDim\" : [ \"listDim1v1\", \"listDim1v2\" ]";
-  private static final String DIM3 = "\"dim3\" : 1";
-  private static final String DIM2 = "\"dim2\" : \"d2v1\"";
-  private static final String DIM1 = "\"dim1\" : \"d1v1\"";
-  private static final String METRIC1 = "\"metric1\" : 1";
-  private static final String TIMESTAMP = "\"timestamp\" : 1537229880023";
-  private static final int FLAT_JSON_LENGTH = 148;
 
   private static final String NESTED_JSON = "{\n"
                                             + "  \"nestedData\" : {\n"
@@ -101,15 +95,12 @@ public class FlattenSpecParquetReaderTest extends BaseParquetReaderTest
         flattenSpec
     );
     List<InputRowListPlusRawValues> sampled = sampleAllRows(reader);
-    String actualReaderStringValue = DEFAULT_JSON_WRITER.writeValueAsString(sampled.get(0).getRawValues());
+    
+    ObjectMapper obj = new ObjectMapper();
+    JsonNode expectedJson = obj.readTree(FLAT_JSON);
 
-    Assert.assertTrue(actualReaderStringValue.contains(LISTDIM));
-    Assert.assertTrue(actualReaderStringValue.contains(DIM1));
-    Assert.assertTrue(actualReaderStringValue.contains(DIM2));
-    Assert.assertTrue(actualReaderStringValue.contains(DIM3));
-    Assert.assertTrue(actualReaderStringValue.contains(METRIC1));
-    Assert.assertTrue(actualReaderStringValue.contains(TIMESTAMP));
-    Assert.assertTrue(FLAT_JSON_LENGTH, actualReaderStringValue.length());
+    JsonNode sampledAsStringJson = obj.readTree(DEFAULT_JSON_WRITER.writeValueAsString(sampled.get(0).getRawValues()));
+    Assert.assertEquals(expectedJson, sampledAsStringJson);
   }
 
   @Test

--- a/extensions-core/parquet-extensions/src/test/java/org/apache/druid/data/input/parquet/FlattenSpecParquetReaderTest.java
+++ b/extensions-core/parquet-extensions/src/test/java/org/apache/druid/data/input/parquet/FlattenSpecParquetReaderTest.java
@@ -50,6 +50,13 @@ public class FlattenSpecParquetReaderTest extends BaseParquetReaderTest
                                           + "  \"timestamp\" : 1537229880023\n"
                                           + "}";
 
+  private static final String LISTDIM = "\"listDim\" : [ \"listDim1v1\", \"listDim1v2\" ]";
+  private static final String DIM3 = "\"dim3\" : 1";
+  private static final String DIM2 = "\"dim2\" : \"d2v1\"";
+  private static final String DIM1 = "\"dim1\" : \"d1v1\"";
+  private static final String METRIC1 = "\"metric1\" : 1";
+  private static final String TIMESTAMP = "\"timestamp\" : 1537229880023";
+
   private static final String NESTED_JSON = "{\n"
                                             + "  \"nestedData\" : {\n"
                                             + "    \"listDim\" : [ \"listDim1v1\", \"listDim1v2\" ],\n"
@@ -93,7 +100,14 @@ public class FlattenSpecParquetReaderTest extends BaseParquetReaderTest
         flattenSpec
     );
     List<InputRowListPlusRawValues> sampled = sampleAllRows(reader);
-    Assert.assertEquals(FLAT_JSON, DEFAULT_JSON_WRITER.writeValueAsString(sampled.get(0).getRawValues()));
+    String actualReaderStringValue = DEFAULT_JSON_WRITER.writeValueAsString(sampled.get(0).getRawValues());
+
+    Assert.assertTrue(actualReaderStringValue.contains(LISTDIM));
+    Assert.assertTrue(actualReaderStringValue.contains(DIM1));
+    Assert.assertTrue(actualReaderStringValue.contains(DIM2));
+    Assert.assertTrue(actualReaderStringValue.contains(DIM3));
+    Assert.assertTrue(actualReaderStringValue.contains(METRIC1));
+    Assert.assertTrue(actualReaderStringValue.contains(TIMESTAMP));
   }
 
   @Test

--- a/extensions-core/parquet-extensions/src/test/java/org/apache/druid/data/input/parquet/FlattenSpecParquetReaderTest.java
+++ b/extensions-core/parquet-extensions/src/test/java/org/apache/druid/data/input/parquet/FlattenSpecParquetReaderTest.java
@@ -56,6 +56,7 @@ public class FlattenSpecParquetReaderTest extends BaseParquetReaderTest
   private static final String DIM1 = "\"dim1\" : \"d1v1\"";
   private static final String METRIC1 = "\"metric1\" : 1";
   private static final String TIMESTAMP = "\"timestamp\" : 1537229880023";
+  private static final int FLAT_JSON_LENGTH = 148;
 
   private static final String NESTED_JSON = "{\n"
                                             + "  \"nestedData\" : {\n"
@@ -108,6 +109,7 @@ public class FlattenSpecParquetReaderTest extends BaseParquetReaderTest
     Assert.assertTrue(actualReaderStringValue.contains(DIM3));
     Assert.assertTrue(actualReaderStringValue.contains(METRIC1));
     Assert.assertTrue(actualReaderStringValue.contains(TIMESTAMP));
+    Assert.assertTrue(FLAT_JSON_LENGTH, actualReaderStringValue.length());
   }
 
   @Test


### PR DESCRIPTION
The test [parquet.FlattenSpecParquetReaderTest.testFlat1NoFlattenSpec](https://github.com/deekshacheruku/druid/blob/25ef9a26379b795347269b7cf90ed1f78cf3f253/extensions-core/parquet-extensions/src/test/java/org/apache/druid/data/input/parquet/FlattenSpecParquetReaderTest.java#L73C1-L113C4) was asserting a string which was originally a map coming from a reader. It was failing because of the ordering of the key value pairs. I didn't want to change the project source code, hence changed the way of testing. The devlopers might have a particular reason behind using a map and then were converting to a string.

I found and confirmed the flaky behavior using an open-source research tool [NonDex](https://github.com/TestingResearchIllinois/NonDex), which shuffles implementations of nondeterminism operations.

This test is fixed using the Jackson library which contains classes JsonNode and ObjectMapper. These are used to parse two JSON strings to tree models and then compare these trees node by node. 

You can run the following command to reproduce assertion failures and verify the fix:

```
mvn edu.illinois:nondex-maven-plugin:2.1.1:nondex -pl extensions-core/parquet-extensions Dtest=org.apache.druid.data.input.parquet.FlattenSpecParquetReaderTest#testFlat1NoFlattenSpec
```


Test Environment:

```
openjdk version "11.0.20.1"
Apache Maven 3.6.3
Ubuntu 20.04.6 LTS
Linux version 5.4.0-156-generic
```

Please let me know if you have any concerns or questions.