### PR TITLE
Fixed Flaky tests in ParserTest.java

### DIFF
--- a/processing/src/test/java/org/apache/druid/math/expr/ParserTest.java
+++ b/processing/src/test/java/org/apache/druid/math/expr/ParserTest.java
@@ -38,6 +38,7 @@ import org.junit.rules.ExpectedException;
 import java.math.BigInteger;
 import java.nio.ByteBuffer;
 import java.util.Collections;
+import java.util.HashSet;
 import java.util.List;
 import java.util.Set;
 
@@ -820,7 +821,7 @@ public class ParserTest extends InitializedNullHandlingTest
     }
     final Expr.BindingAnalysis deets = parsed.analyzeInputs();
     Assert.assertEquals(expression, expected, parsed.toString());
-    Assert.assertEquals(expression, identifiers, deets.getRequiredBindingsList());
+    Assert.assertEquals(expression, new HashSet<>(identifiers), deets.getRequiredBindings());
     Assert.assertEquals(expression, scalars, deets.getScalarVariables());
     Assert.assertEquals(expression, arrays, deets.getArrayVariables());
 
@@ -828,7 +829,7 @@ public class ParserTest extends InitializedNullHandlingTest
     final Expr roundTrip = Parser.parse(parsedNoFlatten.stringify(), ExprMacroTable.nil());
     Assert.assertEquals(parsed.stringify(), roundTrip.stringify());
     final Expr.BindingAnalysis roundTripDeets = roundTrip.analyzeInputs();
-    Assert.assertEquals(expression, identifiers, roundTripDeets.getRequiredBindingsList());
+    Assert.assertEquals(expression, new HashSet<>(identifiers), roundTripDeets.getRequiredBindings());
     Assert.assertEquals(expression, scalars, roundTripDeets.getScalarVariables());
     Assert.assertEquals(expression, arrays, roundTripDeets.getArrayVariables());
   }


### PR DESCRIPTION
**Description**

Fixes the following 6 flaky tests in found org.apache.druid.math.expr.ParserTest.


[org.apache.druid.math.expr.ParserTest.testFunctions](https://github.com/deekshacheruku/druid/blob/ad32f8458670339808a3136a9578a10a52b8394f/processing/src/test/java/org/apache/druid/math/expr/ParserTest.java#L450C1-L502C4)
[org.apache.druid.math.expr.ParserTest.testApplyFunctions](https://github.com/deekshacheruku/druid/blob/ad32f8458670339808a3136a9578a10a52b8394f/processing/src/test/java/org/apache/druid/math/expr/ParserTest.java#L505C1-L587C4)
[org.apache.druid.math.expr.ParserTest.testSimpleAdditivityOp1](https://github.com/deekshacheruku/druid/blob/ad32f8458670339808a3136a9578a10a52b8394f/processing/src/test/java/org/apache/druid/math/expr/ParserTest.java#L177C1-L181C4)
[org.apache.druid.math.expr.ParserTest.testSimpleAdditivityOp2](https://github.com/deekshacheruku/druid/blob/ad32f8458670339808a3136a9578a10a52b8394f/processing/src/test/java/org/apache/druid/math/expr/ParserTest.java#L184C1-L192C4)
[org.apache.druid.math.expr.ParserTest.testSimpleLogicalOps1](https://github.com/deekshacheruku/druid/blob/ad32f8458670339808a3136a9578a10a52b8394f/processing/src/test/java/org/apache/druid/math/expr/ParserTest.java#L163C1-L174C4)
[org.apache.druid.math.expr.ParserTest.testSimpleMultiplicativeOp1](https://github.com/deekshacheruku/druid/blob/ad32f8458670339808a3136a9578a10a52b8394f/processing/src/test/java/org/apache/druid/math/expr/ParserTest.java#L195C2-L200C4)

**Root Cause**

The above mentioned tests have been reported as flaky when ran against the [NonDex](https://github.com/TestingResearchIllinois/NonDex) tool. The tests failed because they were trying to compare a Array List of strings (getRequiredBindingsList) to a hardcode string converted to a List (identifiers). The List in Java does not store the inserted order of their values. As a result, when the expected converted List is compared with the actual ArrayList, it failed.

**Fix**

Used the existing method which returns a set [getRequiredBindings()](https://github.com/deekshacheruku/druid/blob/ad32f8458670339808a3136a9578a10a52b8394f/processing/src/main/java/org/apache/druid/math/expr/Expr.java#L513C2-L516C6) instead of [getRequiredBindingsList()](https://github.com/deekshacheruku/druid/blob/ad32f8458670339808a3136a9578a10a52b8394f/processing/src/main/java/org/apache/druid/math/expr/Expr.java#L505C2-L508C6) and compared it with `identifiers` converted to a HashSet. getRequiredBindings() returns a set of identifiers while getRequiredBindingsList() wraps a list around the set returned by getRequiredBindings()

**How has this been tested?**

**Java:** openjdk version "11.0.20.1"
**Maven:** Apache Maven 3.6.3

Module Build - Successful
Command used - `mvn install -pl processing -am -DskipTests`

Regular Test - Successful
Commands used - 
`mvn -pl processing test -Dtest=<above mentioned tests>`

Non Dex Test - Failed
Commands used - 
`mvn -pl processing edu.illinois:nondex-maven-plugin:2.1.1:nondex -Dtest=<above mentioned tests>`

NonDex test passed after the fix.